### PR TITLE
raster_cog: add new layer type for remote Cloud Optimized GeoTIFFs

### DIFF
--- a/geomanager/admin/__init__.py
+++ b/geomanager/admin/__init__.py
@@ -9,6 +9,7 @@ from geomanager.admin.category import CategoryModelAdmin
 from geomanager.admin.dataset import DatasetModelAdmin
 from geomanager.admin.mbt_source import MBTSourceModelAdmin
 from geomanager.admin.metadata import MetadataModelAdmin
+from geomanager.admin.raster_cog import RasterCOGLayerModelAdmin, urls as raster_cog_urls
 from geomanager.admin.raster_file import RasterFileLayerModelAdmin, RasterFileModelAdmin, urls as raster_file_urls
 from geomanager.admin.raster_style import RasterStyleModelAdmin
 from geomanager.admin.raster_tile import RasterTileLayerModelAdmin, urls as raster_tile_urls
@@ -19,6 +20,7 @@ from geomanager.models import GeomanagerSettings
 
 urls = raster_file_urls \
        + raster_tile_urls \
+       + raster_cog_urls \
        + vector_file_urls \
        + vector_tile_urls \
        + wms_urls \
@@ -45,6 +47,7 @@ class GeoManagerAdminGroup(ModelAdminGroupWithHiddenItems):
         DatasetModelAdmin,
         MetadataModelAdmin,
         RasterFileLayerModelAdmin,
+        RasterCOGLayerModelAdmin,
         RasterStyleModelAdmin,
         VectorFileLayerModelAdmin,
         WmsLayerModelAdmin,

--- a/geomanager/admin/raster_cog.py
+++ b/geomanager/admin/raster_cog.py
@@ -1,0 +1,106 @@
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
+from wagtail_modeladmin.helpers import AdminURLHelper
+from wagtail_modeladmin.views import CreateView, EditView
+
+from geomanager.admin.base import BaseModelAdmin, LayerIndexView, ModelAdminCanHide
+from geomanager.models import Category, Dataset, RasterCOGLayer
+
+
+class RasterCOGLayerCreateView(CreateView):
+    def get_form(self):
+        form = super().get_form()
+        form.fields["dataset"].queryset = Dataset.objects.filter(layer_type="raster_cog")
+
+        dataset_id = self.request.GET.get("dataset_id")
+        if dataset_id:
+            initial = {**form.initial}
+            initial.update({"dataset": dataset_id})
+            form.initial = initial
+        return form
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+
+        category_admin_helper = AdminURLHelper(Category)
+        category_index_url = category_admin_helper.get_action_url("index")
+
+        datasets_admin_helper = AdminURLHelper(Dataset)
+        datasets_index_url = datasets_admin_helper.get_action_url("index")
+
+        navigation_items = [
+            {"url": category_index_url, "label": Category._meta.verbose_name_plural},
+            {"url": datasets_index_url, "label": Dataset._meta.verbose_name_plural},
+            {"url": "#", "label": _("New") + f" {RasterCOGLayer._meta.verbose_name}"},
+        ]
+
+        context_data.update({"navigation_items": navigation_items})
+        return context_data
+
+
+class RasterCOGLayerEditView(EditView):
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+
+        category_admin_helper = AdminURLHelper(Category)
+        category_index_url = category_admin_helper.get_action_url("index")
+
+        datasets_admin_helper = AdminURLHelper(Dataset)
+        datasets_index_url = datasets_admin_helper.get_action_url("index")
+
+        layer_admin_helper = AdminURLHelper(RasterCOGLayer)
+        layer_index_url = layer_admin_helper.get_action_url("index")
+
+        navigation_items = [
+            {"url": category_index_url, "label": Category._meta.verbose_name_plural},
+            {"url": datasets_index_url, "label": Dataset._meta.verbose_name_plural},
+            {"url": layer_index_url, "label": RasterCOGLayer._meta.verbose_name_plural},
+            {"url": "#", "label": self.instance.title},
+        ]
+
+        context_data.update({"navigation_items": navigation_items})
+        return context_data
+
+
+class RasterCOGLayerModelAdmin(BaseModelAdmin, ModelAdminCanHide):
+    model = RasterCOGLayer
+
+    index_template_name = "geomanager/modeladmin/index_without_custom_create.html"
+
+    exclude_from_explorer = True
+    hidden = True
+
+    index_view_class = LayerIndexView
+    create_view_class = RasterCOGLayerCreateView
+    edit_view_class = RasterCOGLayerEditView
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.list_display = (list(self.list_display) or []) + ['dataset_link', "mapviewer_map_url"]
+        self.dataset_link.__func__.short_description = _('Dataset')
+        self.mapviewer_map_url.__func__.short_description = _("View on MapViewer")
+
+    def mapviewer_map_url(self, obj):
+        label = _("MapViewer")
+        button_html = f"""
+                <a href="{obj.mapviewer_map_url}" target="_blank" rel="noopener noreferrer" class="button button-small button--icon button-secondary">
+                    <span class="icon-wrapper">
+                        <svg class="icon icon-map icon" aria-hidden="true">
+                            <use href="#icon-map"></use>
+                        </svg>
+                    </span>
+                    {label}
+                </a>
+            """
+        return mark_safe(button_html)
+
+    def dataset_link(self, obj):
+        button_html = f"""
+            <a href="{obj.dataset.dataset_url()}">
+                {obj.dataset.title}
+            </a>
+        """
+        return mark_safe(button_html)
+
+
+urls = []

--- a/geomanager/helpers.py
+++ b/geomanager/helpers.py
@@ -24,6 +24,10 @@ def get_layer_action_url(layer_type, action, action_args=None):
         from geomanager.models.vector_tile import VectorTileLayer
         vector_tile_layer_admin_helper = AdminURLHelper(VectorTileLayer)
         url = vector_tile_layer_admin_helper.get_action_url(action, action_args)
+    elif layer_type == "raster_cog":
+        from geomanager.models.raster_cog import RasterCOGLayer
+        raster_cog_layer_admin_helper = AdminURLHelper(RasterCOGLayer)
+        url = raster_cog_layer_admin_helper.get_action_url(action, action_args)
     else:
         url = None
 

--- a/geomanager/migrations/0054_rastercoglayer.py
+++ b/geomanager/migrations/0054_rastercoglayer.py
@@ -1,0 +1,133 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import django_extensions.db.fields
+import uuid
+import wagtail.blocks
+import wagtail.fields
+import wagtail.images.blocks
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('geomanager', '0053_wmslayer_legend_from_capabilities'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='dataset',
+            name='layer_type',
+            field=models.CharField(
+                choices=[
+                    ('raster_file', 'Raster File - NetCDF/GeoTiff'),
+                    ('vector_file', 'Vector File - Shapefile, Geojson'),
+                    ('wms', 'Web Map Service - WMS Layer'),
+                    ('raster_tile', 'XYZ Raster Tile Layer'),
+                    ('vector_tile', 'XYZ Vector Tile Layer'),
+                    ('raster_cog', 'Raster COG - Cloud Optimized GeoTIFF (remote URL)'),
+                ],
+                default='raster_file',
+                max_length=100,
+                verbose_name='Layer type',
+            ),
+        ),
+        migrations.CreateModel(
+            name='RasterCOGLayer',
+            fields=[
+                ('created', django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, verbose_name='created')),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified')),
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('title', models.CharField(help_text='Layer title', max_length=255, verbose_name='title')),
+                ('default', models.BooleanField(default=False, help_text='Is Default Layer', verbose_name='default')),
+                ('order', models.IntegerField(blank=True, editable=False, null=True)),
+                ('url_template', models.CharField(
+                    help_text='URL template with a time placeholder. Supported placeholders: '
+                              '{time:strftime} (e.g. {time:%Y}, {time:%Y-%m-%d}), {year}, {month}, {day}, {hour}. '
+                              'Example: https://example.org/data/file_{time:%Y}.tif',
+                    max_length=2048,
+                    verbose_name='COG URL template',
+                )),
+                ('time_start', models.DateTimeField(
+                    help_text='First timestamp of the series (inclusive)',
+                    verbose_name='Start time',
+                )),
+                ('time_end', models.DateTimeField(
+                    help_text='Last timestamp of the series (inclusive)',
+                    verbose_name='End time',
+                )),
+                ('time_step_value', models.PositiveIntegerField(default=1, verbose_name='Time step value')),
+                ('time_step_unit', models.CharField(
+                    choices=[
+                        ('years', 'Years'),
+                        ('months', 'Months'),
+                        ('days', 'Days'),
+                        ('hours', 'Hours'),
+                    ],
+                    default='years',
+                    max_length=20,
+                    verbose_name='Time step unit',
+                )),
+                ('date_format', models.CharField(
+                    blank=True,
+                    choices=[
+                        ('yyyy-MM-dd HH:mm', 'Hour minute:second - (E.g 2023-01-01 00:00)'),
+                        ('yyyy-MM-dd', 'Day - (E.g 2023-01-01)'),
+                        ('pentadal', 'Pentadal - (E.g Jan 2023 - P1 1-5th)'),
+                        ('dekadal', 'Dekadal - (E.g Jan 2023 - D1 1-10th)'),
+                        ('yyyy-MM', 'Month number - (E.g 2023-01)'),
+                        ('MMMM yyyy', 'Month name - (E.g January 2023)'),
+                        ('yyyy', 'Year - (E.g 2023)'),
+                    ],
+                    default='yyyy-MM-dd HH:mm',
+                    max_length=100,
+                    null=True,
+                    verbose_name='Display Format for DateTime Selector',
+                )),
+                ('use_custom_legend', models.BooleanField(default=False, verbose_name='Use custom legend')),
+                ('legend', wagtail.fields.StreamField(
+                    [
+                        ('legend', wagtail.blocks.StructBlock([
+                            ('type', wagtail.blocks.ChoiceBlock(choices=[
+                                ('basic', 'Basic'),
+                                ('gradient', 'Gradient'),
+                                ('choropleth', 'Choropleth'),
+                            ], label='Legend Type')),
+                            ('items', wagtail.blocks.ListBlock(wagtail.blocks.StructBlock([
+                                ('value', wagtail.blocks.CharBlock(
+                                    help_text="Can be a number or text e.g '10' or '10-20' or 'Vegetation'",
+                                    label='value',
+                                )),
+                                ('color', wagtail.blocks.CharBlock(
+                                    help_text='Color value e.g rgb(73,73,73) or #494949',
+                                    label='color',
+                                )),
+                            ]), label='Legend Items', min_num=1)),
+                        ], label='Custom Legend')),
+                        ('legend_image', wagtail.images.blocks.ImageChooserBlock(label='Custom Image')),
+                    ],
+                    blank=True,
+                    null=True,
+                    use_json_field=True,
+                    verbose_name='Legend',
+                )),
+                ('dataset', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='raster_cog_layers',
+                    to='geomanager.dataset',
+                    verbose_name='dataset',
+                )),
+                ('style', models.ForeignKey(
+                    blank=True,
+                    null=True,
+                    on_delete=django.db.models.deletion.SET_NULL,
+                    to='geomanager.rasterstyle',
+                    verbose_name='style',
+                )),
+            ],
+            options={
+                'verbose_name': 'Raster COG Layer',
+                'verbose_name_plural': 'Raster COG Layers',
+                'ordering': ['order'],
+            },
+        ),
+    ]

--- a/geomanager/models/__init__.py
+++ b/geomanager/models/__init__.py
@@ -8,6 +8,7 @@ from .core import *
 from .geomanager_settings import *
 from .geostore import *
 from .profile import *
+from .raster_cog import *
 from .raster_file import *
 from .raster_tile import *
 from .tile_gl import *
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @receiver(post_save, sender=GeomanagerSettings)
 @receiver(post_save, sender=RasterFileLayer)
 @receiver(post_save, sender=LayerRasterFile)
+@receiver(post_save, sender=RasterCOGLayer)
 @receiver(post_save, sender=RasterStyle)
 @receiver(post_save, sender=WmsLayer)
 @receiver(post_save, sender=MBTSource)

--- a/geomanager/models/core.py
+++ b/geomanager/models/core.py
@@ -110,6 +110,7 @@ class Dataset(TimeStampedModel, AdminSortable):
         ("wms", _("Web Map Service - WMS Layer")),
         ("raster_tile", _("XYZ Raster Tile Layer")),
         ("vector_tile", _("XYZ Vector Tile Layer")),
+        ("raster_cog", _("Raster COG - Cloud Optimized GeoTIFF (remote URL)")),
     )
 
     CURRENT_TIME_METHOD_CHOICES = (
@@ -264,6 +265,9 @@ class Dataset(TimeStampedModel, AdminSortable):
 
         if layer_type == "vector_tile":
             return self.vector_tile_layers
+
+        if layer_type == "raster_cog":
+            return self.raster_cog_layers
 
         return None
 

--- a/geomanager/models/raster_cog.py
+++ b/geomanager/models/raster_cog.py
@@ -1,0 +1,258 @@
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from dateutil.relativedelta import relativedelta
+from django_extensions.db.models import TimeStampedModel
+from wagtail.admin.panels import FieldPanel, MultiFieldPanel
+from wagtail.api.v2.utils import get_full_url
+from wagtail.fields import StreamField
+from wagtail.images.blocks import ImageChooserBlock
+from wagtail.images.models import Image
+from wagtail_modeladmin.helpers import AdminURLHelper
+
+from geomanager.blocks import InlineLegendBlock
+from geomanager.models.core import BaseLayer, Dataset
+from geomanager.models.raster_style import RasterStyle
+from geomanager.utils import DATE_FORMAT_CHOICES
+
+
+TIME_STEP_UNIT_CHOICES = (
+    ("years", _("Years")),
+    ("months", _("Months")),
+    ("days", _("Days")),
+    ("hours", _("Hours")),
+)
+
+TIME_PLACEHOLDER_KEYS = ("time", "year", "month", "day", "hour")
+
+
+class RasterCOGLayer(TimeStampedModel, BaseLayer):
+    dataset = models.ForeignKey(Dataset, on_delete=models.CASCADE, related_name="raster_cog_layers",
+                                verbose_name=_("dataset"))
+
+    url_template = models.CharField(
+        max_length=2048,
+        verbose_name=_("COG URL template"),
+        help_text=_("URL template with a time placeholder. Supported placeholders: "
+                    "{time:strftime} (e.g. {time:%Y}, {time:%Y-%m-%d}), {year}, {month}, {day}, {hour}. "
+                    "Example: https://example.org/data/file_{time:%Y}.tif"),
+    )
+    time_start = models.DateTimeField(
+        verbose_name=_("Start time"),
+        help_text=_("First timestamp of the series (inclusive)"),
+    )
+    time_end = models.DateTimeField(
+        verbose_name=_("End time"),
+        help_text=_("Last timestamp of the series (inclusive)"),
+    )
+    time_step_value = models.PositiveIntegerField(
+        default=1,
+        verbose_name=_("Time step value"),
+    )
+    time_step_unit = models.CharField(
+        max_length=20,
+        choices=TIME_STEP_UNIT_CHOICES,
+        default="years",
+        verbose_name=_("Time step unit"),
+    )
+
+    date_format = models.CharField(max_length=100, choices=DATE_FORMAT_CHOICES, blank=True, null=True,
+                                   default="yyyy-MM-dd HH:mm",
+                                   verbose_name=_("Display Format for DateTime Selector"))
+    style = models.ForeignKey("RasterStyle", null=True, blank=True, on_delete=models.SET_NULL, verbose_name=_("style"))
+    use_custom_legend = models.BooleanField(default=False, verbose_name=_("Use custom legend"))
+    legend = StreamField([
+        ('legend', InlineLegendBlock(label=_("Custom Legend")),),
+        ('legend_image', ImageChooserBlock(label=_("Custom Image")),),
+    ], use_json_field=True, null=True, blank=True, max_num=1, verbose_name=_("Legend"), )
+
+    class Meta:
+        verbose_name = _("Raster COG Layer")
+        verbose_name_plural = _("Raster COG Layers")
+        ordering = ['order']
+
+    panels = [
+        FieldPanel("dataset"),
+        FieldPanel("title"),
+        FieldPanel("default"),
+        MultiFieldPanel([
+            FieldPanel("url_template"),
+            FieldPanel("time_start"),
+            FieldPanel("time_end"),
+            FieldPanel("time_step_value"),
+            FieldPanel("time_step_unit"),
+        ], heading=_("COG source")),
+        FieldPanel("date_format"),
+        FieldPanel("style"),
+        FieldPanel("use_custom_legend"),
+        FieldPanel("legend"),
+    ]
+
+    def __str__(self):
+        return f"{self.dataset.title} - {self.title}"
+
+    def get_style_url(self):
+        url = {"action": _("Create Style")}
+        style_admin_helper = AdminURLHelper(RasterStyle)
+        if self.style:
+            url.update({
+                "action": _("Edit Style"),
+                "url": style_admin_helper.get_action_url("edit", self.style.pk)
+            })
+        else:
+            url.update({
+                "url": style_admin_helper.get_action_url("create") + f"?layer_id={str(self.pk)}"
+            })
+        return url
+
+    def _format_url(self, tick):
+        return self.url_template.format(
+            time=tick,
+            year=tick.year,
+            month=tick.month,
+            day=tick.day,
+            hour=tick.hour,
+        )
+
+    def enumerate_entries(self):
+        delta = relativedelta(**{self.time_step_unit: self.time_step_value})
+        entries = []
+        current = self.time_start
+        # Guard against zero-step infinite loop (validated in clean(), but cheap belt-and-braces)
+        if self.time_step_value == 0:
+            return [(self.time_start, self._format_url(self.time_start))]
+
+        while current <= self.time_end:
+            entries.append((current, self._format_url(current)))
+            current = current + delta
+        return entries
+
+    def get_color_ramp(self):
+        if self.style:
+            return self.style.get_color_ramp()
+        return None
+
+    def get_tile_json_url(self, request=None):
+        url = reverse("raster_cog_tilejson", args=(self.id,))
+        if request:
+            url = get_full_url(request, url)
+        return url
+
+    def layer_config(self, request=None):
+        return {
+            "type": "raster",
+            "source": {
+                "type": "cog",
+                "tilejson": self.get_tile_json_url(request),
+            }
+        }
+
+    @property
+    def params(self):
+        return {"time": ""}
+
+    @property
+    def param_selector_config(self):
+        if self.dataset.multi_layer:
+            default_layer = self.dataset.layers.filter(default=True).exclude(pk=self.pk).first()
+            if default_layer:
+                return default_layer.param_selector_config
+
+        time_config = {
+            "key": "time",
+            "required": True,
+            "sentence": "{selector}",
+            "type": "datetime",
+            "availableDates": [],
+        }
+
+        if self.date_format:
+            if self.date_format == "pentadal":
+                time_config.update({"dateFormat": {"currentTime": "MMM yyyy", "asPeriod": "pentadal"}})
+            elif self.date_format == "dekadal":
+                time_config.update({"dateFormat": {"currentTime": "MMM yyyy", "asPeriod": "dekadal"}})
+            else:
+                time_config.update({"dateFormat": {"currentTime": self.date_format}})
+        else:
+            time_config.update({"dateFormat": {"currentTime": "yyyy-MM-dd HH:mm"}})
+
+        return [time_config]
+
+    def get_legend_config(self, request=None):
+        config = {"type": "choropleth", "items": []}
+
+        if self.style:
+            if self.use_custom_legend:
+                legend_block = self.legend
+                if legend_block:
+                    legend_block = legend_block[0]
+
+                if legend_block:
+                    if isinstance(legend_block.value, Image):
+                        image_url = legend_block.value.file.url
+                        image_url = get_full_url(request, image_url)
+                        config.update({"type": "image", "imageUrl": image_url})
+                        return config
+
+                    data = legend_block.block.get_api_representation(legend_block.value)
+                    config.update({"type": data.get("type")})
+                    for item in data.get("items"):
+                        config["items"].append({
+                            "name": item.get("value"),
+                            "color": item.get("color")
+                        })
+                    return config
+
+            return self.style.get_legend_config()
+
+        return config
+
+    def get_tile_json(self, request=None):
+        entries = self.enumerate_entries()
+        timestamps = [t.strftime("%Y-%m-%dT%H:%M:%S.000Z") for t, _u in entries]
+        urls = {t.strftime("%Y-%m-%dT%H:%M:%S.000Z"): u for t, u in entries}
+
+        return {
+            "tilejson": "3.0.0",
+            "name": self.title,
+            "scheme": "xyz",
+            "time_parameter": "time",
+            "timestamps": timestamps,
+            "urls": urls,
+        }
+
+    def clean(self):
+        if self._state.adding:
+            if self.dataset.has_layers() and not self.dataset.multi_layer:
+                raise ValidationError(_("Can not add layer because the dataset is not marked as Multi Layer. "
+                                        "To add multiple layers to a dataset, please mark the dataset as "
+                                        "Multi Layer and try again"))
+
+        if self.time_end and self.time_start and self.time_end < self.time_start:
+            raise ValidationError({"time_end": _("End time must be greater than or equal to start time")})
+
+        if self.time_step_value == 0:
+            raise ValidationError({"time_step_value": _("Time step value must be greater than 0")})
+
+        if self.url_template:
+            has_placeholder = any(f"{{{key}" in self.url_template for key in TIME_PLACEHOLDER_KEYS)
+            if not has_placeholder:
+                raise ValidationError({"url_template": _(
+                    "URL template must contain at least one time placeholder "
+                    "({time:strftime}, {year}, {month}, {day} or {hour})"
+                )})
+
+            if self.time_start:
+                try:
+                    start_url = self._format_url(self.time_start)
+                except (KeyError, IndexError, ValueError) as e:
+                    raise ValidationError({"url_template": _("Invalid URL template: %(error)s") % {"error": str(e)}})
+
+                if self.time_end and self.time_end != self.time_start:
+                    end_url = self._format_url(self.time_end)
+                    if start_url == end_url:
+                        raise ValidationError({"url_template": _(
+                            "URL template produces the same URL for start and end times. "
+                            "Add a time-dependent placeholder."
+                        )})

--- a/geomanager/models/raster_style.py
+++ b/geomanager/models/raster_style.py
@@ -216,6 +216,37 @@ class RasterStyle(TimeStampedModel, ClusterableModel):
         }
         return style
     
+    def get_color_ramp(self):
+        """Return a renderer-friendly color ramp for client-side rasters (e.g. COG)."""
+        if self.use_custom_colors:
+            stops = [
+                {"value": cv.threshold, "color": cv.color}
+                for cv in self.color_values.order_by('threshold')
+            ]
+            return {
+                "type": "step",
+                "min": self.min,
+                "max": self.max,
+                "stops": stops,
+                "restColor": self.custom_color_for_rest,
+                "unit": self.unit,
+            }
+
+        palette = self.get_palette_list()
+        if not palette or len(palette) < 2:
+            return None
+
+        n = len(palette)
+        step = (self.max - self.min) / (n - 1)
+        stops = [{"value": self.min + i * step, "color": color} for i, color in enumerate(palette)]
+        return {
+            "type": "interpolate" if self.interpolate else "step",
+            "min": self.min,
+            "max": self.max,
+            "stops": stops,
+            "unit": self.unit,
+        }
+
     def get_legend_config(self):
         items = []
         legend_type = self.legend_type

--- a/geomanager/serializers/core.py
+++ b/geomanager/serializers/core.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from geomanager.models import Category
 from geomanager.models.core import SubCategory, Dataset, Metadata
+from geomanager.serializers.raster_cog import RasterCOGLayerSerializer
 from geomanager.serializers.raster_file import RasterFileLayerSerializer
 from geomanager.serializers.raster_tile import RasterTileLayerSerializer
 from geomanager.serializers.vector_file import VectorFileLayerSerializer
@@ -49,6 +50,9 @@ class DatasetSerializer(serializers.ModelSerializer):
 
         if obj.layer_type == "vector_tile":
             return VectorTileLayerSerializer(obj.vector_tile_layers, many=True, context={"request": request}).data
+
+        if obj.layer_type == "raster_cog":
+            return RasterCOGLayerSerializer(obj.raster_cog_layers, many=True, context={"request": request}).data
 
         return None
 

--- a/geomanager/serializers/raster_cog.py
+++ b/geomanager/serializers/raster_cog.py
@@ -1,0 +1,82 @@
+from rest_framework import serializers
+
+from geomanager.models import RasterCOGLayer
+
+
+class RasterCOGLayerSerializer(serializers.ModelSerializer):
+    layerConfig = serializers.SerializerMethodField()
+    params = serializers.SerializerMethodField()
+    paramsSelectorConfig = serializers.SerializerMethodField()
+    legendConfig = serializers.SerializerMethodField()
+    colorRamp = serializers.SerializerMethodField()
+    name = serializers.SerializerMethodField()
+    layerType = serializers.SerializerMethodField()
+    multiTemporal = serializers.SerializerMethodField()
+    currentTimeMethod = serializers.SerializerMethodField()
+    autoUpdateInterval = serializers.SerializerMethodField()
+    isMultiLayer = serializers.SerializerMethodField()
+    nestedLegend = serializers.SerializerMethodField()
+    canClip = serializers.SerializerMethodField()
+    tileJsonUrl = serializers.SerializerMethodField()
+    isDefault = serializers.SerializerMethodField()
+    linkedLayers = serializers.SerializerMethodField()
+    showAllMultiLayer = serializers.SerializerMethodField()
+
+    class Meta:
+        model = RasterCOGLayer
+        fields = ["id", "dataset", "isDefault", "name", "layerType", "multiTemporal", "isMultiLayer", "legendConfig",
+                  "colorRamp", "nestedLegend", "layerConfig", "params", "paramsSelectorConfig", "currentTimeMethod",
+                  "autoUpdateInterval", "canClip", "tileJsonUrl", "linkedLayers", "showAllMultiLayer"]
+
+    def get_linkedLayers(self, obj):
+        return obj.linked_layers
+
+    def get_showAllMultiLayer(self, obj):
+        return obj.dataset.enable_all_multi_layers_on_add
+
+    def get_isDefault(self, obj):
+        return obj.default
+
+    def get_isMultiLayer(self, obj):
+        return obj.dataset.multi_layer
+
+    def get_nestedLegend(self, obj):
+        return obj.dataset.multi_layer
+
+    def get_autoUpdateInterval(self, obj):
+        return obj.dataset.auto_update_interval_milliseconds
+
+    def get_multiTemporal(self, obj):
+        return obj.dataset.multi_temporal
+
+    def get_layerType(self, obj):
+        return obj.dataset.layer_type
+
+    def get_name(self, obj):
+        return obj.title
+
+    def get_layerConfig(self, obj):
+        request = self.context.get('request')
+        return obj.layer_config(request)
+
+    def get_tileJsonUrl(self, obj):
+        request = self.context.get('request')
+        return obj.get_tile_json_url(request)
+
+    def get_params(self, obj):
+        return obj.params
+
+    def get_paramsSelectorConfig(self, obj):
+        return obj.param_selector_config
+
+    def get_legendConfig(self, obj):
+        return obj.get_legend_config()
+
+    def get_colorRamp(self, obj):
+        return obj.get_color_ramp()
+
+    def get_currentTimeMethod(self, obj):
+        return obj.dataset.current_time_method
+
+    def get_canClip(self, obj):
+        return obj.dataset.can_clip

--- a/geomanager/urls.py
+++ b/geomanager/urls.py
@@ -24,6 +24,7 @@ from .views.profile import (
     get_geomanager_user_profile,
     create_or_update_geomanager_user_profile
 )
+from .views.raster_cog import raster_cog_as_tilejson
 from .views.raster_file import (
     RasterDataPixelView,
     RasterDataPixelTimeseriesView,
@@ -106,6 +107,8 @@ urlpatterns = [
                   # Tile JSON
                   path(r'api/raster/<uuid:layer_id>/tiles.json', raster_file_as_tile_json,
                        name="raster_file_tile_json"),
+                  path(r'api/raster-cog/<uuid:layer_id>/tilejson.json', raster_cog_as_tilejson,
+                       name="raster_cog_tilejson"),
 
                   # Tiles
                   path(r'api/raster-tiles/<uuid:layer_id>/<int:z>/<int:x>/<int:y>', RasterTileView.as_view(),

--- a/geomanager/views/raster_cog.py
+++ b/geomanager/views/raster_cog.py
@@ -1,0 +1,9 @@
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+
+from geomanager.models import RasterCOGLayer
+
+
+def raster_cog_as_tilejson(request, layer_id):
+    layer = get_object_or_404(RasterCOGLayer, pk=layer_id)
+    return JsonResponse(layer.get_tile_json(request))


### PR DESCRIPTION
Introduces a `raster_cog` layer type alongside the existing `raster_file`, following the same convention as `raster_tile` (URL-based) vs `raster_file` (uploaded). Targets datasets where the COG is hosted remotely and read directly by the client via HTTP range requests, avoiding any server-side tiling.

- New RasterCOGLayer model with URL template + temporal range (start/end/step) — server enumerates {time, url} pairs at serialization
- Multi-temporal handled via template (e.g. `{time:%Y}`) instead of per-timestamp upload, since real COG datasets (Copernicus, CMIP, ECMWF) typically follow a regular naming pattern
- TileJSON-like endpoint `/api/raster-cog/<layer_id>/tilejson.json` exposing the enumerated timestamps + URLs
- Serializer emits a `colorRamp` field derived from RasterStyle so the frontend can apply colorization client-side (no server tiling)
- Reuses existing RasterStyle for color management

No analysis endpoints (pixel/geostore) for raster_cog at this stage — they can be added later by reading remote COGs via rasterio /vsicurl/.